### PR TITLE
短消息，回复时，没有用户名输入的自动提示功能，需要将相应的代码屏蔽掉，否则报js错误

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/admin/personal/message/sendForm.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/personal/message/sendForm.jsp
@@ -159,14 +159,16 @@
         });
 
         var $username = $("#receiverId_msg");
-        $.app.initAutocomplete({
-            input : $username,
-            source : "${ctx}/admin/sys/user/ajax/autocomplete",
-            select : function(event, ui) {
-                $username.val(ui.item.label);
-                return false;
-            }
-        });
+        if($username[0]){
+            $.app.initAutocomplete({
+                input : $username,
+                source : "${ctx}/admin/sys/user/ajax/autocomplete",
+                select : function(event, ui) {
+                    $username.val(ui.item.label);
+                    return false;
+                }
+            });
+        }
 
         $(window).on('beforeunload',function() {
             if($username.val() || $("#title").val() || editor.html()) {


### PR DESCRIPTION
短消息，回复时，没有用户名输入的自动提示功能，需要将相应的代码屏蔽掉，否则报js错误
并且影响后续btn初始化的js执行，以及离开页面的警告提示也会失效
