### PR TITLE
fixed #56 添加jcaptcha-api的maven依赖

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -655,6 +655,11 @@
         <!-- jcaptcha 验证码 -->
         <dependency>
             <groupId>com.octo.captcha</groupId>
+            <artifactId>jcaptcha-api</artifactId>
+            <version>${jcaptcha.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.octo.captcha</groupId>
             <artifactId>jcaptcha</artifactId>
             <version>${jcaptcha.version}</version>
         </dependency>

--- a/web/src/main/java/com/sishuok/es/maintain/task/service/DynamicTaskService.java
+++ b/web/src/main/java/com/sishuok/es/maintain/task/service/DynamicTaskService.java
@@ -6,9 +6,7 @@
 package com.sishuok.es.maintain.task.service;
 
 import com.sishuok.es.common.service.BaseService;
-import com.sishuok.es.maintain.icon.entity.Icon;
 import com.sishuok.es.maintain.task.entity.DynamicTask;
-import com.sishuok.es.maintain.task.repository.IconRepository;
 import org.springframework.stereotype.Service;
 
 /**


### PR DESCRIPTION
添加jcaptcha-api的maven依赖

``` xml
<dependency>
    <groupId>com.octo.captcha</groupId>
    <artifactId>jcaptcha-api</artifactId>
    <version>${jcaptcha.version}</version>
</dependency>
```
