### PR TITLE
修改`总在线时长`显示错误问题

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/admin/sys/user/loginUser/editForm.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/sys/user/loginUser/editForm.jsp
@@ -93,7 +93,7 @@
             <div class="control-group">
                 <label class="control-label">总在线时长</label>
                 <div class="controls">
-                    <input type="text" value="<time:prettySecond seconds="${lastOnline.totalOnlineTime}"/>"/>
+                    <input type="text" value="<time:prettySecond seconds='lastOnline.totalOnlineTime'/>"/>
                 </div>
             </div>
         </c:if>


### PR DESCRIPTION
登录演示[地址](http://demo.kaifazhe.me/es/login)
点击`admin ，欢迎您！`进入个人资料页面
在`上次登录历史`一栏中`总在线时长`.
